### PR TITLE
Add frontend into the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ RUN CGO_ENABLED=0 GOOS=linux go build -mod=vendor -o go-websocket-chat-demo .
 FROM heroku/heroku:18
 WORKDIR /app
 COPY --from=0 /src/go-websocket-chat-demo /app
+COPY ./public /app/public
 CMD ["./go-websocket-chat-demo"]


### PR DESCRIPTION
Users see a "404 not found" error on this app's / page.
This is because ./public is not being copied into the container
at all. This patch addresses that. Verified manually

Signed-by: Ahmet Alp Balkan <ahmetb@google.com>